### PR TITLE
Add ipv4.rainway.com direct rule

### DIFF
--- a/China.list
+++ b/China.list
@@ -153,6 +153,9 @@ DOMAIN-KEYWORD,amplifi,Domestic
 USER-AGENT,NeteaseMusic*
 USER-AGENT,%E7%BD%91%E6%98%93%E4%BA%91%E9%9F%B3%E4%B9%90*
 
+# Rainway
+DOMAIN,ipv4.rainway.com
+
 # Client
 
 # >> Proxy

--- a/China.list
+++ b/China.list
@@ -155,6 +155,8 @@ USER-AGENT,%E7%BD%91%E6%98%93%E4%BA%91%E9%9F%B3%E4%B9%90*
 
 # Rainway
 DOMAIN,ipv4.rainway.com
+DOMAIN,ipv6.rainway.com
+DOMAIN,cya.gg
 
 # Client
 


### PR DESCRIPTION
Rainway is a cloud gaming service. `ipv4.rainway.com` is used to detect the client's IP address hence it should be directly connected instead of thru a proxy.