### PR TITLE
Add domain used by Apple audio apps

### DIFF
--- a/Anti-GFW.list
+++ b/Anti-GFW.list
@@ -8,6 +8,7 @@ DOMAIN,books.itunes.apple.com
 DOMAIN,hls.itunes.apple.com
 DOMAIN,itunes.apple.com
 DOMAIN,lookup-api.apple.com
+DOMAIN,audiocontentdownload.apple.com
 
 # >> Google
 DOMAIN-SUFFIX,abc.xyz


### PR DESCRIPTION
Domain audiocontentdownload.apple.com is used by GarageBand, Logic Pro and MainStage for downloading Sound Library from Internet. For China domestic, the DNS records for this domain usually point to an Akamai’s CDN node with a bad IP route.

域名 audiocontentdownload.apple.com 被库乐队（GarageBand）、Logic Pro 和 MainStage 用于从因特网下载声音资源库。对于中国国内，该网域的域名系统记录通常会指向一个网际协议路由不佳的 Akamai 的内容分发网络节点。