### PR TITLE
Add domain rule for SHOWTIME as stream

### DIFF
--- a/Stream.list
+++ b/Stream.list
@@ -324,4 +324,8 @@ USER-AGENT,com.google.ios.youtube*
 USER-AGENT,YouTube*
 USER-AGENT,YouTubeMusic*
 
+# >> SHOWTIME
+DOMAIN-SUFFIX,sho.com
+DOMAIN-SUFFIX,showtime.com
+
 # --- End of Stream Service Section ---


### PR DESCRIPTION
showtime.com is an online video provider in the US.  The series *homeland* is broadcast on that website.