### PR TITLE
Add rixcloudstatus.com to China.list

### DIFF
--- a/China.list
+++ b/China.list
@@ -2,6 +2,7 @@
 
 # >>rixCloud
 DOMAIN,analytics.rixcloud.app
+DOMAIN,rixcloudstatus.com
 
 # > 360
 DOMAIN-SUFFIX,qhimg.com


### PR DESCRIPTION
将 rixcloudstatus.com 加入国内可访问列表，以便在「rixCloud 策略组」所使用的代理接入点暂时不可用时及时且方便地（不必手动更改 Surge 工作状态或重新选择接入点）访问该状态页面。